### PR TITLE
Update prerequisites.rst

### DIFF
--- a/prerequisites.rst
+++ b/prerequisites.rst
@@ -14,7 +14,7 @@ Prerequisites
 * html2text
 * pytz
 * redis
-* mollie-api-python
+* mollie-api-python < 2.0 (e.g. pip install -Iv mollie-api-python==1.4.2)
 * weasyprint
 * Pillow
 * pybarcode


### PR DESCRIPTION
Doesn't work with mollie-api-python 2.0.1, works with 1.4.2